### PR TITLE
Only publish reporter when on AppVeyor.

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ var AppVeyorReporter = function (baseReporterDecorator, config, logger, helper, 
 AppVeyorReporter.$inject = ['baseReporterDecorator', 'config', 'logger', 'helper', 'formatError']
 
 // PUBLISH DI MODULE
-module.exports = {
-  'reporter:appveyor': ['type', AppVeyorReporter]
+if(process.env.APPVEYOR_API_URL) {
+  module.exports = {
+    'reporter:appveyor': ['type', AppVeyorReporter]
+  }
 }


### PR DESCRIPTION
When running this reporter on the command-line, all requests time out. Resulting in a delay of about a minute each time tests are run.